### PR TITLE
ci: publish containers to GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,32 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
-
-permissions:
-  contents: read
+    branches: [ main ]
 
 jobs:
-  ci:
-    name: Build, Test, and Lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Build
-        run: make build
-
-      - name: Test
-        run: make test
-
-      - name: Lint
-        run: make lint
+  call-common-ci:
+    uses: its-the-vibe/.github/.github/workflows/common-ci.yaml@main
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,25 @@
 # Build stage
-FROM golang:1.26.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /build
 
-# Copy all source files
+# Copy go mod and source files
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o redisrelay .
 
-# Download dependencies and build
-# Note: If you encounter TLS errors during build, ensure your Docker environment has proper CA certificates
-RUN go mod download && \
-    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o redisrelay .
-
-# Runtime stage
-FROM scratch
-
-# Copy CA certificates for HTTPS connections if needed
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+# Runtime stage (distroless)
+FROM gcr.io/distroless/static-debian13:nonroot
 
 # Copy the binary from builder
 COPY --from=builder /build/redisrelay /redisrelay
+
+USER nonroot:nonroot
 
 # Set the entrypoint
 ENTRYPOINT ["/redisrelay"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: ghcr.io/its-the-vibe/redisrelay:latest
+    pull_policy: always
     read_only: true
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    image: redisrelay:latest
     container_name: redisrelay
     restart: on-failure:10
     volumes:


### PR DESCRIPTION
## Summary
- Build cross-platform static binary using `--platform=$BUILDPLATFORM` with `TARGETOS`/`TARGETARCH` args
- Switch runtime from `scratch` to `gcr.io/distroless/static-debian13:nonroot` (removes CA cert copy and `apk add ca-certificates`)
- Add `USER nonroot:nonroot` instruction
- Update Compose to use GHCR image with `pull_policy: always`
- Delegate CI/CD to the shared organisation workflow (with `secrets: inherit`)